### PR TITLE
Update README.md

### DIFF
--- a/LogTransformation/README.md
+++ b/LogTransformation/README.md
@@ -3,7 +3,7 @@
 ---
 
 Log transformation maps a narrow range of low-intensity input values to a wide range of output values. The image is made up of two horizontal bands. The first band depicts the grayscale color space from 0 (black) on the left and all the way up to 255 (white) on the right end of the spectrum. Log-transformed band is much more brighter than its counterpart. The log transform essentially magnifies the differences in intensity of pixels in the darker end of the grayscale spectrum at the cost of diminishing differences at the brighter end. 
-Mathematically, log transformations can be expressed as s = clog(1+r). 
+Mathematically, log transformations can be expressed as s = clog(1+r) 
 
 ---
 


### PR DESCRIPTION
Log transformation maps a narrow range of low-intensity input values to a wide range of output values. The image is made up of two horizontal bands. The first band depicts the grayscale color space from 0 (black) on the left and all the way up to 255 (white) on the right end of the spectrum. Log-transformed band is much more brighter than its counterpart. The log transform essentially magnifies the differences in intensity of pixels in the darker end of the grayscale spectrum at the cost of diminishing differences at the brighter end. 
Mathematically, log transformations can be expressed as s = clog(1+r)